### PR TITLE
Fix #7 by enforcing valid input register block size.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -586,6 +586,15 @@ impl Config {
                 if inv.read_timeout.unwrap_or(900) == 0 {
                     return Err(anyhow!("config.rs:Invalid read timeout: 0"));
                 }
+                if let Some(register_block_size) = inv.register_block_size {
+                    if register_block_size != 40 {
+                        bail!(
+                            "inverter[{}].register_block_size={} is invalid; must be 40 (current parser supports blocks starting at 0,40,80,120,160,200)",
+                            i,
+                            register_block_size
+                        );
+                    }
+                }
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -589,7 +589,7 @@ impl Config {
                 if let Some(register_block_size) = inv.register_block_size {
                     if register_block_size != 40 {
                         bail!(
-                            "inverter[{}].register_block_size={} is invalid; must be 40 (current parser supports blocks starting at 0,40,80,120,160,200)",
+                            "inverter[{}].register_block_size={} is invalid; the current implementation only supports a register_block_size of 40",
                             i,
                             register_block_size
                         );

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -14,16 +14,14 @@ impl Scheduler {
 
     async fn read_input_registers(&self, inverter: &config::Inverter) -> Result<()> {
         let configured_block_size = inverter.register_block_size();
-        let block_size = if configured_block_size == 40 {
-            40
-        } else {
+        if configured_block_size != 40 {
             error!(
                 "Invalid register_block_size={} for inverter {}; falling back to 40",
                 configured_block_size,
                 inverter.serial().unwrap_or_default()
             );
-            40
-        };
+        }
+        let block_size = 40;
         
         // Read all input register blocks
         for start_register in (0..=200).step_by(block_size as usize) {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -13,7 +13,17 @@ impl Scheduler {
     }
 
     async fn read_input_registers(&self, inverter: &config::Inverter) -> Result<()> {
-        let block_size = inverter.register_block_size();
+        let configured_block_size = inverter.register_block_size();
+        let block_size = if configured_block_size == 40 {
+            40
+        } else {
+            error!(
+                "Invalid register_block_size={} for inverter {}; falling back to 40",
+                configured_block_size,
+                inverter.serial().unwrap_or_default()
+            );
+            40
+        };
         
         // Read all input register blocks
         for start_register in (0..=200).step_by(block_size as usize) {

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -56,8 +56,12 @@ databases: []
     )
     .unwrap();
 
-    let config = Config::new(temp.path().to_string_lossy().to_string());
-    assert!(config.is_err());
+    let err = Config::new(temp.path().to_string_lossy().to_string()).unwrap_err();
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("register_block_size") || err_msg.contains("must be 40"),
+        "expected register_block_size validation error, got: {err_msg}"
+    );
 }
 
 #[test]

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -4,6 +4,7 @@ use eg4_bridge::mqtt;
 use eg4_bridge::config;
 use eg4_bridge::eg4;
 use std::str::FromStr;
+use std::io::Write;
 use serde_json::json;
 use eg4_bridge::config::Config;
 
@@ -23,6 +24,40 @@ fn config_returns_ok() {
     let config = Config::new("config.yaml.example".to_owned());
 
     assert!(config.is_ok());
+}
+
+#[test]
+fn config_rejects_invalid_register_block_size() {
+    let mut temp = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        temp,
+        r#"
+loglevel: info
+strict_data_check: false
+homeassistant_enabled: false
+read_only: false
+register_read_interval: 60
+inverters:
+  - enabled: true
+    host: 127.0.0.1
+    port: 8000
+    serial: "5555555555"
+    datalog: "2222222222"
+    register_block_size: 127
+mqtt:
+  enabled: false
+  host: localhost
+influx:
+  enabled: false
+  url: http://localhost:8086
+  database: eg4
+databases: []
+"#
+    )
+    .unwrap();
+
+    let config = Config::new(temp.path().to_string_lossy().to_string());
+    assert!(config.is_err());
 }
 
 #[test]


### PR DESCRIPTION
Reject non-40 register_block_size values in config and add a scheduler safety fallback so invalid settings cannot generate unhandled ReadInput register sequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes configuration validation and the scheduler’s register-read loop; misconfiguration now fails fast (or falls back) which could affect deployments relying on non-40 values, but scope is limited to register reading.
> 
> **Overview**
> **Enforces a single supported Modbus input register block size.** Config validation now rejects any inverter `register_block_size` other than `40` with a clear error.
> 
> **Hardens scheduling reads against bad settings.** The scheduler now logs and falls back to `40` if an unexpected block size is encountered, preventing invalid `step_by` sequences.
> 
> Adds a regression test that asserts configs with an invalid `register_block_size` are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3f615dd3543ea037994a7f20cfb0075834b575. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->