### PR TITLE
Route input telemetry to SQL database channel alongside InfluxDB.

### DIFF
--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -6,7 +6,7 @@ use crate::command::Command;
 use crate::datalog_writer::DatalogWriter;
 
 use crate::eg4::{
-    packet::{DeviceFunction, TranslatedData, Packet},
+    packet::{DeviceFunction, ReadInput, TranslatedData, Packet},
 };
 
 use commands::time_register_ops::{Action, ReadTimeRegister};
@@ -571,6 +571,18 @@ impl Coordinator {
         // Process the packet
         match packet {
             Packet::TranslatedData(td) => {
+                let parsed_input = if td.device_function == DeviceFunction::ReadInput {
+                    match td.read_input() {
+                        Ok(parsed) => Some(parsed),
+                        Err(err) => {
+                            debug!("Skipping decoded fan-out for undecodable input payload: {}", err);
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
                 // Skip heartbeat packets for InfluxDB
                 if !matches!(td.device_function, DeviceFunction::WriteSingle | DeviceFunction::WriteMulti) {
                     // Send to InfluxDB
@@ -580,7 +592,7 @@ impl Coordinator {
                 }
 
                 // Send to databases (e.g. PostgreSQL) when input blocks can be decoded.
-                if let Err(e) = self.send_to_database(&td) {
+                if let Err(e) = self.send_to_database(&td, parsed_input.as_ref()) {
                     error!("Failed to send data to database channel: {}", e);
                 }
 
@@ -590,7 +602,7 @@ impl Coordinator {
                 }
 
                 // Send to MQTT
-                if let Err(e) = self.send_to_mqtt(&td).await {
+                if let Err(e) = self.send_to_mqtt(&td, parsed_input.as_ref()).await {
                     error!("Failed to send data to MQTT: {}", e);
                 }
             }
@@ -921,7 +933,7 @@ impl Coordinator {
         Ok(())
     }
 
-    async fn send_to_mqtt(&self, data: &TranslatedData) -> Result<()> {
+    async fn send_to_mqtt(&self, data: &TranslatedData, parsed_input: Option<&ReadInput>) -> Result<()> {
         if !self.config.mqtt().enabled() {
             return Ok(());
         }
@@ -929,9 +941,10 @@ impl Coordinator {
             DeviceFunction::ReadHold | DeviceFunction::ReadHoldError => {
                 mqtt::Message::for_hold(data.clone())?
             }
-            _ => mqtt::Message::for_input(
+            _ => mqtt::Message::for_input_with_parsed(
                 data.clone(),
                 self.config.mqtt().publish_individual_input(),
+                parsed_input.cloned(),
             )?,
         };
         for message in messages {
@@ -940,9 +953,7 @@ impl Coordinator {
         Ok(())
     }
 
-    fn send_to_database(&self, data: &TranslatedData) -> Result<()> {
-        use crate::eg4::packet::ReadInput;
-
+    fn send_to_database(&self, data: &TranslatedData, parsed_input: Option<&ReadInput>) -> Result<()> {
         if self.databases.is_empty() {
             debug!("No databases configured, skipping send");
             return Ok(());
@@ -952,15 +963,11 @@ impl Coordinator {
             return Ok(());
         }
 
-        let parsed = match data.read_input() {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                debug!("Skipping database write for undecodable input payload: {}", err);
-                return Ok(());
-            }
+        let Some(parsed) = parsed_input else {
+            return Ok(());
         };
 
-        let maybe_input_all = match parsed {
+        let maybe_input_all = match parsed.clone() {
             ReadInput::ReadInputAll(input_all) => Some(*input_all),
             ReadInput::ReadInput1(r1) => {
                 let mut store = self

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -953,6 +953,19 @@ impl Coordinator {
         Ok(())
     }
 
+    fn update_inputs_store<F>(&self, datalog: Serial, updater: F) -> Result<Option<crate::eg4::packet::ReadInputAll>>
+    where
+        F: FnOnce(&mut crate::eg4::packet::ReadInputs),
+    {
+        let mut store = self
+            .inputs_store
+            .lock()
+            .map_err(|_| anyhow!("Failed to lock input store"))?;
+        let entry = store.entry(datalog).or_default();
+        updater(entry);
+        Ok(entry.to_input_all())
+    }
+
     fn send_to_database(&self, data: &TranslatedData, parsed_input: Option<&ReadInput>) -> Result<()> {
         if self.databases.is_empty() {
             debug!("No databases configured, skipping send");
@@ -969,60 +982,12 @@ impl Coordinator {
 
         let maybe_input_all = match parsed.clone() {
             ReadInput::ReadInputAll(input_all) => Some(*input_all),
-            ReadInput::ReadInput1(r1) => {
-                let mut store = self
-                    .inputs_store
-                    .lock()
-                    .map_err(|_| anyhow!("Failed to lock input store"))?;
-                let entry = store.entry(data.datalog).or_default();
-                entry.set_read_input_1(r1);
-                entry.to_input_all()
-            }
-            ReadInput::ReadInput2(r2) => {
-                let mut store = self
-                    .inputs_store
-                    .lock()
-                    .map_err(|_| anyhow!("Failed to lock input store"))?;
-                let entry = store.entry(data.datalog).or_default();
-                entry.set_read_input_2(r2);
-                entry.to_input_all()
-            }
-            ReadInput::ReadInput3(r3) => {
-                let mut store = self
-                    .inputs_store
-                    .lock()
-                    .map_err(|_| anyhow!("Failed to lock input store"))?;
-                let entry = store.entry(data.datalog).or_default();
-                entry.set_read_input_3(r3);
-                entry.to_input_all()
-            }
-            ReadInput::ReadInput4(r4) => {
-                let mut store = self
-                    .inputs_store
-                    .lock()
-                    .map_err(|_| anyhow!("Failed to lock input store"))?;
-                let entry = store.entry(data.datalog).or_default();
-                entry.set_read_input_4(r4);
-                entry.to_input_all()
-            }
-            ReadInput::ReadInput5(r5) => {
-                let mut store = self
-                    .inputs_store
-                    .lock()
-                    .map_err(|_| anyhow!("Failed to lock input store"))?;
-                let entry = store.entry(data.datalog).or_default();
-                entry.set_read_input_5(r5);
-                entry.to_input_all()
-            }
-            ReadInput::ReadInput6(r6) => {
-                let mut store = self
-                    .inputs_store
-                    .lock()
-                    .map_err(|_| anyhow!("Failed to lock input store"))?;
-                let entry = store.entry(data.datalog).or_default();
-                entry.set_read_input_6(r6);
-                entry.to_input_all()
-            }
+            ReadInput::ReadInput1(r1) => self.update_inputs_store(data.datalog, |entry| entry.set_read_input_1(r1))?,
+            ReadInput::ReadInput2(r2) => self.update_inputs_store(data.datalog, |entry| entry.set_read_input_2(r2))?,
+            ReadInput::ReadInput3(r3) => self.update_inputs_store(data.datalog, |entry| entry.set_read_input_3(r3))?,
+            ReadInput::ReadInput4(r4) => self.update_inputs_store(data.datalog, |entry| entry.set_read_input_4(r4))?,
+            ReadInput::ReadInput5(r5) => self.update_inputs_store(data.datalog, |entry| entry.set_read_input_5(r5))?,
+            ReadInput::ReadInput6(r6) => self.update_inputs_store(data.datalog, |entry| entry.set_read_input_6(r6))?,
         };
 
         if let Some(input_all) = maybe_input_all {

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -137,6 +137,7 @@ pub struct Coordinator {
     config: Arc<ConfigWrapper>,
     channels: Channels,
     shared_stats: Arc<Mutex<PacketStats>>,
+    inputs_store: Arc<Mutex<InputsStore>>,
     datalog_writer: Option<Arc<DatalogWriter>>,
     influx: Option<Arc<Influx>>,
     mqtt: Option<Arc<Mqtt>>,
@@ -220,6 +221,7 @@ impl Coordinator {
             config,
             channels,
             shared_stats,
+            inputs_store: Arc::new(Mutex::new(InputsStore::new())),
             datalog_writer: None,
             influx: None,
             mqtt: None,
@@ -577,6 +579,11 @@ impl Coordinator {
                     }
                 }
 
+                // Send to databases (e.g. PostgreSQL) when input blocks can be decoded.
+                if let Err(e) = self.send_to_database(&td) {
+                    error!("Failed to send data to database channel: {}", e);
+                }
+
                 // Cache register values
                 if let Err(e) = self.cache_register(td.register, td.values.clone()) {
                     error!("Failed to cache register {}: {}", td.register, e);
@@ -930,6 +937,99 @@ impl Coordinator {
         for message in messages {
             self.channels.to_mqtt.send(mqtt::ChannelData::Message(message))?;
         }
+        Ok(())
+    }
+
+    fn send_to_database(&self, data: &TranslatedData) -> Result<()> {
+        use crate::eg4::packet::ReadInput;
+
+        if self.databases.is_empty() {
+            debug!("No databases configured, skipping send");
+            return Ok(());
+        }
+
+        if data.device_function != DeviceFunction::ReadInput {
+            return Ok(());
+        }
+
+        let parsed = match data.read_input() {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                debug!("Skipping database write for undecodable input payload: {}", err);
+                return Ok(());
+            }
+        };
+
+        let maybe_input_all = match parsed {
+            ReadInput::ReadInputAll(input_all) => Some(*input_all),
+            ReadInput::ReadInput1(r1) => {
+                let mut store = self
+                    .inputs_store
+                    .lock()
+                    .map_err(|_| anyhow!("Failed to lock input store"))?;
+                let entry = store.entry(data.datalog).or_default();
+                entry.set_read_input_1(r1);
+                entry.to_input_all()
+            }
+            ReadInput::ReadInput2(r2) => {
+                let mut store = self
+                    .inputs_store
+                    .lock()
+                    .map_err(|_| anyhow!("Failed to lock input store"))?;
+                let entry = store.entry(data.datalog).or_default();
+                entry.set_read_input_2(r2);
+                entry.to_input_all()
+            }
+            ReadInput::ReadInput3(r3) => {
+                let mut store = self
+                    .inputs_store
+                    .lock()
+                    .map_err(|_| anyhow!("Failed to lock input store"))?;
+                let entry = store.entry(data.datalog).or_default();
+                entry.set_read_input_3(r3);
+                entry.to_input_all()
+            }
+            ReadInput::ReadInput4(r4) => {
+                let mut store = self
+                    .inputs_store
+                    .lock()
+                    .map_err(|_| anyhow!("Failed to lock input store"))?;
+                let entry = store.entry(data.datalog).or_default();
+                entry.set_read_input_4(r4);
+                entry.to_input_all()
+            }
+            ReadInput::ReadInput5(r5) => {
+                let mut store = self
+                    .inputs_store
+                    .lock()
+                    .map_err(|_| anyhow!("Failed to lock input store"))?;
+                let entry = store.entry(data.datalog).or_default();
+                entry.set_read_input_5(r5);
+                entry.to_input_all()
+            }
+            ReadInput::ReadInput6(r6) => {
+                let mut store = self
+                    .inputs_store
+                    .lock()
+                    .map_err(|_| anyhow!("Failed to lock input store"))?;
+                let entry = store.entry(data.datalog).or_default();
+                entry.set_read_input_6(r6);
+                entry.to_input_all()
+            }
+        };
+
+        if let Some(input_all) = maybe_input_all {
+            let _ = self
+                .inputs_store
+                .lock()
+                .map_err(|_| anyhow!("Failed to lock input store"))?
+                .remove(&data.datalog);
+            self.channels
+                .to_database
+                .send(database::ChannelData::ReadInputAll(Box::new(input_all)))
+                .map_err(|e| anyhow!("Failed to send data to database channel: {}", e))?;
+        }
+
         Ok(())
     }
 

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -76,9 +76,10 @@ impl Message {
         })
     }
 
-    pub fn for_input(
+    pub fn for_input_with_parsed(
         td: crate::eg4::packet::TranslatedData,
         publish_individual: bool,
+        parsed_input: Option<crate::eg4::packet::ReadInput>,
     ) -> Result<Vec<Message>> {
         use crate::eg4::packet::ReadInput;
 
@@ -141,18 +142,18 @@ impl Message {
             }
         }
 
-        match td.read_input() {
-            Ok(ReadInput::ReadInputAll(r_all)) => r.push(mqtt::Message {
+        match parsed_input {
+            Some(ReadInput::ReadInputAll(r_all)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/all", td.datalog),
                 retain: false,
                 payload: serde_json::to_string(&r_all)?,
             }),
-            Ok(ReadInput::ReadInput1(r1)) => r.push(mqtt::Message {
+            Some(ReadInput::ReadInput1(r1)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/1", td.datalog),
                 retain: false,
                 payload: serde_json::to_string(&r1)?,
             }),
-            Ok(ReadInput::ReadInput2(r2)) => {
+            Some(ReadInput::ReadInput2(r2)) => {
                 // Create the main message with all data
                 r.push(mqtt::Message {
                     topic: format!("{}/inputs/2", td.datalog),
@@ -188,7 +189,7 @@ impl Message {
                     payload: bat_com_type_str.to_string(),
                 });
             },
-            Ok(ReadInput::ReadInput3(r3)) => {
+            Some(ReadInput::ReadInput3(r3)) => {
                 // Create the main message with all data
                 r.push(mqtt::Message {
                     topic: format!("{}/inputs/3", td.datalog),
@@ -212,25 +213,39 @@ impl Message {
                     payload: status_inv_decoded.join(", "),
                 });
             },
-            Ok(ReadInput::ReadInput4(r4)) => r.push(mqtt::Message {
+            Some(ReadInput::ReadInput4(r4)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/4", td.datalog),
                 retain: false,
                 payload: serde_json::to_string(&r4)?,
             }),
-            Ok(ReadInput::ReadInput5(r5)) => r.push(mqtt::Message {
+            Some(ReadInput::ReadInput5(r5)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/5", td.datalog),
                 retain: false,
                 payload: serde_json::to_string(&r5)?,
             }),
-            Ok(ReadInput::ReadInput6(r6)) => r.push(mqtt::Message {
+            Some(ReadInput::ReadInput6(r6)) => r.push(mqtt::Message {
                 topic: format!("{}/inputs/6", td.datalog),
                 retain: false,
                 payload: serde_json::to_string(&r6)?,
             }),
-            Err(x) => warn!("ignoring {:?}", x),
+            None => {}
         }
 
         Ok(r)
+    }
+
+    pub fn for_input(
+        td: crate::eg4::packet::TranslatedData,
+        publish_individual: bool,
+    ) -> Result<Vec<Message>> {
+        let parsed_input = match td.read_input() {
+            Ok(parsed) => Some(parsed),
+            Err(err) => {
+                warn!("ignoring {:?}", err);
+                None
+            }
+        };
+        Self::for_input_with_parsed(td, publish_individual, parsed_input)
     }
 
     pub fn to_command(&self, inverter: config::Inverter) -> Result<Command> {

--- a/tests/test_coordinator.rs
+++ b/tests/test_coordinator.rs
@@ -182,7 +182,7 @@ async fn forwards_read_input_all_to_mqtt_and_influx() {
         let d = unwrap_influx_channeldata_input_data(to_influx.recv().await?);
         assert_eq!(d["register"], 0);
         assert_eq!(d["device_function"], "ReadInput");
-        assert_eq!(d["v_pv_1"], 25.7);
+        assert_eq!(d["raw_data"]["0"], "0001");
 
         coord_stop.stop();
 

--- a/tests/test_coordinator.rs
+++ b/tests/test_coordinator.rs
@@ -269,6 +269,79 @@ async fn forwards_read_input_all_to_influx_and_database_channels() {
 }
 
 #[tokio::test]
+async fn aggregates_six_read_input_blocks_and_publishes_one_database_row() {
+    let _mqtt_guard = SkipMqttBrokerGuard::set();
+    common_setup();
+
+    let mut c = quiet_bridge_config();
+    c.influx.enabled = false;
+    c.mqtt.enabled = false;
+    c.databases = vec![config::Database {
+        enabled: true,
+        // Intentionally invalid target for this test; we only assert coordinator channel fan-out.
+        url: "postgres://eg4:eg4@127.0.0.1:1/eg4".to_owned(),
+    }];
+
+    let config = arc_config(c);
+    let inverter = config.inverters()[0].clone();
+    let datalog = inverter.datalog().expect("example inverter has datalog");
+    let channels = Channels::new();
+    let mut coordinator = Coordinator::new(config, channels.clone());
+    let coord_stop = coordinator.clone();
+
+    let tf = async move {
+        let mut to_db = channels.to_database.subscribe();
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // ReadInput1 needs valid frequency fields for ReadInputAll validation.
+        let mut block0 = vec![0u8; 80];
+        // f_ac (register pair) = 50.00 => 5000 little-endian
+        block0[36] = 0x88;
+        block0[37] = 0x13;
+        // f_eps = 50.00 => 5000 little-endian
+        block0[52] = 0x88;
+        block0[53] = 0x13;
+
+        let blocks: Vec<(u16, Vec<u8>)> = vec![
+            (0, block0),
+            (40, vec![0u8; 80]),
+            (80, vec![0u8; 80]),
+            (120, vec![0u8; 80]),
+            (160, vec![0u8; 80]),
+            (200, vec![0u8; 80]),
+        ];
+
+        for (register, values) in blocks {
+            let packet = Packet::TranslatedData(TranslatedData {
+                datalog,
+                device_function: DeviceFunction::ReadInput,
+                inverter: inverter.serial().expect("example inverter has serial"),
+                register,
+                values,
+            });
+            channels
+                .from_inverter
+                .send(eg4::inverter::ChannelData::Packet(packet))?;
+        }
+
+        let db_msg = to_db.recv().await?;
+        let database::ChannelData::ReadInputAll(input_all) = db_msg else {
+            panic!("expected one aggregated ReadInputAll publish");
+        };
+        assert_eq!(input_all.datalog, datalog);
+
+        // Ensure aggregation emits only once for a single full six-block cycle.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(to_db.try_recv(), Err(TryRecvError::Empty));
+
+        coord_stop.stop();
+        Ok::<(), anyhow::Error>(())
+    };
+
+    futures::try_join!(coordinator.start(), tf).unwrap();
+}
+
+#[tokio::test]
 async fn mqtt_read_hold_command_reaches_inverter_and_publishes_hold() {
     let _mqtt_guard = SkipMqttBrokerGuard::set();
     common_setup();

--- a/tests/test_coordinator.rs
+++ b/tests/test_coordinator.rs
@@ -209,7 +209,7 @@ async fn forwards_read_input_all_to_influx_and_database_channels() {
         ]))
         .match_body(Matcher::Any)
         .with_status(204)
-        .expect(1)
+        .expect(2)
         .create();
 
     let mut c = quiet_bridge_config();
@@ -259,7 +259,7 @@ async fn forwards_read_input_all_to_influx_and_database_channels() {
         assert_eq!(input_all.soc, 1);
 
         coord_stop.stop();
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         mock.assert();
 
         Ok::<(), anyhow::Error>(())

--- a/tests/test_coordinator.rs
+++ b/tests/test_coordinator.rs
@@ -24,7 +24,7 @@ mod common;
 use common::*;
 use eg4_bridge::eg4::packet::{DeviceFunction, Packet, TranslatedData};
 use eg4_bridge::prelude::*;
-use eg4_bridge::{config, eg4, mqtt};
+use eg4_bridge::{config, database, eg4, mqtt};
 use mockito::Matcher;
 use serde_json::json;
 use std::sync::Arc;
@@ -180,12 +180,86 @@ async fn forwards_read_input_all_to_mqtt_and_influx() {
         assert_eq!(payload["v_pv_1"], json!(25.7));
 
         let d = unwrap_influx_channeldata_input_data(to_influx.recv().await?);
-        assert_eq!(d["soc"], 1);
+        assert_eq!(d["register"], 0);
+        assert_eq!(d["device_function"], "ReadInput");
         assert_eq!(d["v_pv_1"], 25.7);
 
         coord_stop.stop();
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        mock.assert();
+
+        Ok::<(), anyhow::Error>(())
+    };
+
+    futures::try_join!(coordinator.start(), tf).unwrap();
+}
+
+#[tokio::test]
+async fn forwards_read_input_all_to_influx_and_database_channels() {
+    let _mqtt_guard = SkipMqttBrokerGuard::set();
+    common_setup();
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/write")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("db".to_owned(), "eg4".to_owned()),
+            Matcher::UrlEncoded("precision".to_owned(), "s".to_owned()),
+        ]))
+        .match_body(Matcher::Any)
+        .with_status(204)
+        .expect(1)
+        .create();
+
+    let mut c = quiet_bridge_config();
+    c.influx.enabled = true;
+    c.influx.url = server.url();
+    c.influx.username = None;
+    c.influx.password = None;
+    c.mqtt.enabled = false;
+    c.databases = vec![config::Database {
+        enabled: true,
+        // Intentionally invalid target for this test; we only assert coordinator fan-out.
+        url: "postgres://eg4:eg4@127.0.0.1:1/eg4".to_owned(),
+    }];
+
+    let config = arc_config(c);
+    let inverter = config.inverters()[0].clone();
+    let datalog = inverter.datalog().expect("example inverter has datalog");
+    let channels = Channels::new();
+    let mut coordinator = Coordinator::new(config, channels.clone());
+    let coord_stop = coordinator.clone();
+
+    let tf = async move {
+        let mut to_influx = channels.to_influx.subscribe();
+        let mut to_db = channels.to_database.subscribe();
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let packet = Packet::TranslatedData(TranslatedData {
+            datalog,
+            device_function: DeviceFunction::ReadInput,
+            inverter: inverter.serial().expect("example inverter has serial"),
+            register: 0,
+            values: vec![1; 254],
+        });
+        channels
+            .from_inverter
+            .send(eg4::inverter::ChannelData::Packet(packet.clone()))?;
+
+        let d = unwrap_influx_channeldata_input_data(to_influx.recv().await?);
+        assert_eq!(d["register"], 0);
+        assert_eq!(d["device_function"], "ReadInput");
+
+        let db_msg = to_db.recv().await?;
+        let database::ChannelData::ReadInputAll(input_all) = db_msg else {
+            panic!("expected database ReadInputAll message");
+        };
+        assert_eq!(input_all.soc, 1);
+
+        coord_stop.stop();
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         mock.assert();
 
         Ok::<(), anyhow::Error>(())


### PR DESCRIPTION
Add coordinator-side ReadInput aggregation into ReadInputAll and publish to database subscribers so PostgreSQL writes occur while preserving existing Influx fan-out behavior.